### PR TITLE
Feature: Adding insert log option to the editor context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -407,7 +407,13 @@
 				"fileMatch": ".vscode/settings.json",
 				"url": "./schemas/config.schema.json"
 			}
-		]
+		],
+        "menus": {
+            "editor/context": [{
+                "command": "codeLogPlus.insertLog",
+                "group": "navigation"
+            }]
+        }
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run compile",

--- a/src/app/controllers/log.controller.ts
+++ b/src/app/controllers/log.controller.ts
@@ -103,6 +103,7 @@ export class LogController {
     await editor.edit((editBuilder) => {
       return editBuilder.insert(insertPosition, logSnippet);
     });
+
     editor.selection = new Selection(nextLineEndPosition, nextLineEndPosition);
   }
 

--- a/src/app/controllers/log.controller.ts
+++ b/src/app/controllers/log.controller.ts
@@ -103,7 +103,6 @@ export class LogController {
     await editor.edit((editBuilder) => {
       return editBuilder.insert(insertPosition, logSnippet);
     });
-
     editor.selection = new Selection(nextLineEndPosition, nextLineEndPosition);
   }
 

--- a/src/app/controllers/log.controller.ts
+++ b/src/app/controllers/log.controller.ts
@@ -8,6 +8,7 @@ import {
   l10n,
   window,
   workspace,
+  Selection,
 } from 'vscode';
 
 import { LogService } from '../services';
@@ -96,6 +97,10 @@ export class LogController {
     );
 
     const insertPosition = new Position(lineNumber + 1, 0);
+    const nextLineEndPosition = editor.document.lineAt(lineNumber + 1).range
+      .end;
+
+    editor.selection = new Selection(nextLineEndPosition, nextLineEndPosition);
     await editor.edit((editBuilder) => {
       return editBuilder.insert(insertPosition, logSnippet);
     });

--- a/src/app/controllers/log.controller.ts
+++ b/src/app/controllers/log.controller.ts
@@ -100,10 +100,10 @@ export class LogController {
     const nextLineEndPosition = editor.document.lineAt(lineNumber + 1).range
       .end;
 
-    editor.selection = new Selection(nextLineEndPosition, nextLineEndPosition);
     await editor.edit((editBuilder) => {
       return editBuilder.insert(insertPosition, logSnippet);
     });
+    editor.selection = new Selection(nextLineEndPosition, nextLineEndPosition);
   }
 
   /**


### PR DESCRIPTION
Hi! 

I created this PR based on a comment I made on an open issue: https://github.com/ManuelGil/vscode-code-log-plus/issues/1#issuecomment-2726330962
During debugging or exploring a piece of code, the mouse is often used more frequently than the keyboard. This is why I thought it would be a great idea to support logging functionality not only with keyboard shortcuts but also with the mouse. When right-clicking on a variable, a new option appears in the context menu: Insert log. 
Additionally, when a new log message is inserted, I position the cursor on the inserted line. This way, if someone is not satisfied with the placement of the log message, it can be quickly moved up or down using the Alt + Up/Down keys.

Here is a demo:
[Képernyőfelvétel 2025-03-16 09-17-26.webm](https://github.com/user-attachments/assets/c6cbd04b-e2ca-47c7-be56-e472a0fef584)

Please let me know if there are any problems with the approach. I'm ready to fix them. Feel free to reject this PR entirely if this is not how you want to approach this functionality.

Thank you for making such a useful extension!